### PR TITLE
feat: remove index multiplier (50) from Equivalent column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
         "@mui/material-nextjs": "^7.1.1",
-        "@mui/x-date-pickers": "^8.10.2",
+        "@mui/x-date-pickers": "^8.11.0",
         "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-query-devtools": "^5.80.7",
         "@tanstack/react-table": "^8.21.3",
@@ -2695,14 +2695,14 @@
       "license": "MIT"
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.10.2.tgz",
-      "integrity": "sha512-eS5t1jUojN/jL2FeJ8gtpCBxIEswUp9kLjM64aJ5LUKrNgM7X9dwsEHyplS+x07kWLiEAhO3nX3mepnS3Z43qg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-8.11.0.tgz",
+      "integrity": "sha512-UHGVG8+zb9GkpUpHHCBCRA4ugrz1XOsGIPTs1cHDtZ/DNkCi+hrhKW1EH5Scoxn9GjE3PXxiN5eH+ZVpeq0jcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.2",
         "@mui/utils": "^7.3.1",
-        "@mui/x-internals": "8.10.2",
+        "@mui/x-internals": "8.11.0",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -2761,9 +2761,9 @@
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.10.2.tgz",
-      "integrity": "sha512-dlC0BQRRBdiWtqn1yDppaHYRUjU3OuPWTxy0UtqxDaJjJf4pfR8ALr243nbxgJAFqvQyWPWyO4A6p9x9eJMJEQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.11.0.tgz",
+      "integrity": "sha512-SFPMLMkNWSEOxIgKMQ9RqEL01klb1lwIdd4f4d18fJNrJOlTxeIDWd6eVllS5sRLdKVsE5FC1802V+yLe6W+pQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
     "@mui/material-nextjs": "^7.1.1",
-    "@mui/x-date-pickers": "^8.10.2",
+    "@mui/x-date-pickers": "^8.11.0",
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-query-devtools": "^5.80.7",
     "@tanstack/react-table": "^8.21.3",

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -43,9 +43,6 @@ export default function DashboardPageV2() {
     selectedIssuers,
   });
 
-  const ulCode =
-    filters.underlying || (underlyings[0]?.code.padStart(5, "0") ?? "");
-
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">CBBC Dashboard</h1>
@@ -83,7 +80,6 @@ export default function DashboardPageV2() {
         isLoadingSingleDate={isLoadingSingleDate}
         singleDateQueryError={singleDateQuery.error}
         singleDateQuery={singleDateQuery}
-        ulCode={ulCode}
       />
     </div>
   );

--- a/src/app/(dashboard)/ko-codes/page.tsx
+++ b/src/app/(dashboard)/ko-codes/page.tsx
@@ -71,7 +71,7 @@ export default function KOCodesPage() {
           No knocked-out codes found.
         </div>
       ) : (
-        <SmartKOTable data={koData} underlying={filters.underlying || "HSI"} />
+        <SmartKOTable data={koData} />
       )}
     </div>
   );

--- a/src/components/CBBCTable/CBBCMatrixRow.tsx
+++ b/src/components/CBBCTable/CBBCMatrixRow.tsx
@@ -37,7 +37,6 @@ type Props = {
   prevDate?: string;
   isExpanded: boolean;
   onToggle: (range: string) => void;
-  underlyingCode: string;
 };
 
 export default function CBBCMatrixRow({
@@ -48,7 +47,6 @@ export default function CBBCMatrixRow({
   prevDate,
   isExpanded,
   onToggle,
-  underlyingCode,
 }: Props) {
   const cellForDate = (date: string) => matrix[range]?.[date];
   console.log("matrix", matrix);
@@ -104,8 +102,7 @@ export default function CBBCMatrixRow({
             } else {
               // Если есть данные в активной дате, показываем их
               const { hkd, usd } = formatCurrencyPair(
-                cell.notional,
-                underlyingCode
+                cell.notional
               );
 
               return (
@@ -152,8 +149,7 @@ export default function CBBCMatrixRow({
           } else if (idx > 0 && idx < 4) {
             // Для остальных дат показываем данные, если они есть
             const { hkd, usd } = formatCurrencyPair(
-              cell?.notional || 0,
-              underlyingCode
+              cell?.notional || 0
             );
 
             return (

--- a/src/components/CBBCTable/CBBCMidSummary.tsx
+++ b/src/components/CBBCTable/CBBCMidSummary.tsx
@@ -5,7 +5,6 @@ interface Props {
   bullTotal: number;
   bearTotal: number;
   currentPrice: number;
-  underlyingCode: string;
   hiddenBearRanges?: number;
   hiddenBullRanges?: number;
 }
@@ -14,7 +13,6 @@ export default function CBBCMidSummary({
   bullTotal,
   bearTotal,
   currentPrice,
-  underlyingCode,
   hiddenBearRanges = 0,
   hiddenBullRanges = 0,
 }: Props) {
@@ -23,8 +21,8 @@ export default function CBBCMidSummary({
   const bearPercent = total ? ((bearTotal / total) * 100).toFixed(1) : "0";
   const ratio = bearTotal === 0 ? "∞" : (bullTotal / bearTotal).toFixed(1);
 
-  const bullCurrency = formatCurrencyPair(bullTotal, underlyingCode);
-  const bearCurrency = formatCurrencyPair(bearTotal, underlyingCode);
+  const bullCurrency = formatCurrencyPair(bullTotal);
+  const bearCurrency = formatCurrencyPair(bearTotal);
 
   return (
     <div className="flex items-center justify-center gap-6 bg-yellow-100 text-sm font-semibold py-2 rounded border border-yellow-300 col-span-full">

--- a/src/components/CBBCTable/GroupedCBBCMetricsMatrix.tsx
+++ b/src/components/CBBCTable/GroupedCBBCMetricsMatrix.tsx
@@ -14,7 +14,6 @@ type Props = {
   bullMatrix: Record<string, Record<string, AggregatedCell>>;
   bearMatrix: Record<string, Record<string, AggregatedCell>>;
   priceByDate: Record<string, number>;
-  underlyingCode: string;
 };
 
 export default function CBBCMatrixTable({
@@ -25,7 +24,6 @@ export default function CBBCMatrixTable({
   bullMatrix,
   bearMatrix,
   priceByDate,
-  underlyingCode,
 }: Props) {
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
   const [showAllBearRanges, setShowAllBearRanges] = useState(false);
@@ -82,7 +80,7 @@ export default function CBBCMatrixTable({
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm border border-gray-300">
-        <CBBCMatrixHeader dateList={dateList} underlyingCode={underlyingCode} />
+        <CBBCMatrixHeader dateList={dateList} />
         <tbody>
           {/* Show More button for Bear ranges */}
           {shouldLimitBearRanges && !showAllBearRanges && (
@@ -130,7 +128,6 @@ export default function CBBCMatrixTable({
                 prevDate={prevDate}
                 isExpanded={expandedRows[`${range}-Bear`] || false}
                 onToggle={() => toggleRow(range, "Bear")}
-                underlyingCode={underlyingCode}
               />
             </Fragment>
           ))}
@@ -142,7 +139,6 @@ export default function CBBCMatrixTable({
                 bullTotal={bullTotal}
                 bearTotal={bearTotal}
                 currentPrice={currentPrice}
-                underlyingCode={underlyingCode}
                 hiddenBearRanges={
                   shouldLimitBearRanges && !showAllBearRanges
                     ? bearRanges.length - maxDisplayedRanges
@@ -168,7 +164,6 @@ export default function CBBCMatrixTable({
                 prevDate={prevDate}
                 isExpanded={expandedRows[`${range}-Bull`] || false}
                 onToggle={() => toggleRow(range, "Bull")}
-                underlyingCode={underlyingCode}
               />
             </Fragment>
           ))}

--- a/src/components/CBBCTable/MatrixHeader.tsx
+++ b/src/components/CBBCTable/MatrixHeader.tsx
@@ -1,16 +1,12 @@
 "use client";
 
 import { formatDateHuman } from "@/lib/utils";
-import { isIndexCode } from "@/lib/utils";
 
 export default function CBBCMatrixHeader({
   dateList,
-  underlyingCode,
 }: {
   dateList: string[];
-  underlyingCode: string;
 }) {
-  const equivalentLabel = isIndexCode(underlyingCode) ? "futures" : "shares";
 
   return (
     <thead>
@@ -38,7 +34,7 @@ export default function CBBCMatrixHeader({
           className="p-2 border border-gray-300 bg-gray-50 text-center font-bold"
           style={{ minWidth: 80 }}
         >
-          Equivalent ({equivalentLabel})
+          Equivalent
         </th>
         <th
           className="p-2 border border-gray-300 bg-gray-50 text-center font-bold"

--- a/src/components/SingleDateCBBCTable.tsx
+++ b/src/components/SingleDateCBBCTable.tsx
@@ -3,16 +3,14 @@ import { SingleDateCBBCItem } from "@/hooks/useSingleDateCBBCQuery";
 
 interface SingleDateCBBCTableProps {
   data: SingleDateCBBCItem[];
-  underlying: string;
 }
 
 export default function SingleDateCBBCTable({
   data,
-  underlying,
 }: SingleDateCBBCTableProps) {
   const formatNotional = (notional: number) => {
     const hkdFormatted = toAbbreviatedNumber(notional);
-    const usdAmount = convertHKDToUSD(notional, underlying);
+    const usdAmount = convertHKDToUSD(notional);
     const usdFormatted = toAbbreviatedNumber(usdAmount);
 
     return (

--- a/src/components/SmartKOTable.tsx
+++ b/src/components/SmartKOTable.tsx
@@ -17,29 +17,25 @@ import { KOCertificate } from "@/hooks/useKOQuery";
 
 interface SmartKOTableProps {
   data: KOCertificate[];
-  underlying: string;
 }
 
-export default function SmartKOTable({ data, underlying }: SmartKOTableProps) {
+export default function SmartKOTable({ data }: SmartKOTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
 
-  const formatNotional = useCallback(
-    (notional: number) => {
-      const hkdFormatted = toAbbreviatedNumber(notional);
-      const usdAmount = convertHKDToUSD(notional, underlying);
-      const usdFormatted = toAbbreviatedNumber(usdAmount);
+  const formatNotional = useCallback((notional: number) => {
+    const hkdFormatted = toAbbreviatedNumber(notional);
+    const usdAmount = convertHKDToUSD(notional);
+    const usdFormatted = toAbbreviatedNumber(usdAmount);
 
-      return (
-        <div className="text-left">
-          <div className="font-medium">HK$ {hkdFormatted}</div>
-          <div className="text-xs text-gray-500">$ {usdFormatted}</div>
-        </div>
-      );
-    },
-    [underlying]
-  );
+    return (
+      <div className="text-left">
+        <div className="font-medium">HK$ {hkdFormatted}</div>
+        <div className="text-xs text-gray-500">$ {usdFormatted}</div>
+      </div>
+    );
+  }, []);
 
   const columns: ColumnDef<KOCertificate>[] = useMemo(
     () => [

--- a/src/components/SmartSingleDateCBBCTable.tsx
+++ b/src/components/SmartSingleDateCBBCTable.tsx
@@ -17,32 +17,27 @@ import { SingleDateCBBCItem } from "@/hooks/useSingleDateCBBCQuery";
 
 interface SmartSingleDateCBBCTableProps {
   data: SingleDateCBBCItem[];
-  underlying: string;
 }
 
 export default function SmartSingleDateCBBCTable({
   data,
-  underlying,
 }: SmartSingleDateCBBCTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
 
-  const formatNotional = useCallback(
-    (notional: number) => {
-      const hkdFormatted = toAbbreviatedNumber(notional);
-      const usdAmount = convertHKDToUSD(notional, underlying);
-      const usdFormatted = toAbbreviatedNumber(usdAmount);
+  const formatNotional = useCallback((notional: number) => {
+    const hkdFormatted = toAbbreviatedNumber(notional);
+    const usdAmount = convertHKDToUSD(notional);
+    const usdFormatted = toAbbreviatedNumber(usdAmount);
 
-      return (
-        <div className="text-left">
-          <div className="font-medium">HK$ {hkdFormatted}</div>
-          <div className="text-xs text-gray-500">$ {usdFormatted}</div>
-        </div>
-      );
-    },
-    [underlying]
-  );
+    return (
+      <div className="text-left">
+        <div className="font-medium">HK$ {hkdFormatted}</div>
+        <div className="text-xs text-gray-500">$ {usdFormatted}</div>
+      </div>
+    );
+  }, []);
 
   const columns: ColumnDef<SingleDateCBBCItem>[] = useMemo(
     () => [

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -29,9 +29,6 @@ interface DashboardContentProps {
   // Query state
   singleDateQueryError?: any;
   singleDateQuery: any;
-
-  // Computed
-  ulCode: string;
 }
 
 /**
@@ -54,7 +51,6 @@ export default function DashboardContent({
   isLoadingSingleDate,
   singleDateQueryError,
   singleDateQuery,
-  ulCode,
 }: DashboardContentProps) {
   const { sendErrorNotification } = useErrorNotification();
 
@@ -82,10 +78,7 @@ export default function DashboardContent({
             </p>
           </div>
 
-          <SmartSingleDateCBBCTable
-            data={filteredSingleDateData}
-            underlying={filters.underlying || "HSI"}
-          />
+          <SmartSingleDateCBBCTable data={filteredSingleDateData} />
         </div>
       );
     }
@@ -141,7 +134,6 @@ export default function DashboardContent({
         bullMatrix={bullMatrix}
         bearMatrix={bearMatrix}
         priceByDate={priceByDate}
-        underlyingCode={filters.underlying || ulCode}
       />
     );
   }

--- a/src/hooks/useCBBCMatrixData.ts
+++ b/src/hooks/useCBBCMatrixData.ts
@@ -5,15 +5,9 @@ import { useMemo } from "react";
 export function useCBBCMatrixData(
   from: string | undefined,
   to: string | undefined,
-  selectedIssuers: string[] = [],
-  underlyingCode?: string
+  selectedIssuers: string[] = []
 ) {
-  const { groupedRawData, underlyings } = useGroupedCBBCStore();
-
-  const underlyingType = underlyingCode
-    ? underlyings.find((u) => u.code === underlyingCode)?.type
-    : undefined;
-  const isIndex = underlyingType === "index";
+  const { groupedRawData } = useGroupedCBBCStore();
 
   const result = useMemo(() => {
     if (!to || !Array.isArray(groupedRawData)) {
@@ -116,10 +110,8 @@ export function useCBBCMatrixData(
         cell.notional += cbcc.notional;
         cell.quantity += cbcc.quantity;
 
-        const adjustedShares = isIndex
-          ? cbcc.shares_number / 50
-          : cbcc.shares_number;
-        cell.shares += Math.round(adjustedShares * 100) / 100;
+        // Используем shares_number как есть для всех типов
+        cell.shares += Math.round(cbcc.shares_number * 100) / 100;
 
         cell.codes.push(cbcc.code.toString());
         cell.items.push({ ...cbcc, date });
@@ -178,7 +170,7 @@ export function useCBBCMatrixData(
       bearMatrix,
       priceByDate,
     };
-  }, [groupedRawData, selectedIssuers, from, to, isIndex]);
+  }, [groupedRawData, selectedIssuers, from, to]);
 
   return result;
 }

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -72,12 +72,7 @@ export function useDashboardData() {
     bullMatrix,
     bearMatrix,
     priceByDate,
-  } = useCBBCMatrixData(
-    filters.from,
-    filters.to,
-    filters.issuers || [],
-    filters.underlying
-  );
+  } = useCBBCMatrixData(filters.from, filters.to, filters.issuers || []);
 
   // Computed display data
   const displayDateList = useMemo(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,7 +56,6 @@ export function formatUnderlyingCode(code: string): string {
 
 // Константы для конвертации валют
 const HKD_TO_USD_RATE = 0.1273;
-const INDEX_MULTIPLIER = 50;
 
 // Список кодов индексов
 const INDEX_CODES = ["HSI", "HSCEI", "HSTEC", "HSTECH"];
@@ -71,30 +70,19 @@ export function isIndexCode(code: string): boolean {
 /**
  * Конвертирует HKD в USD с учетом типа актива
  */
-export function convertHKDToUSD(
-  hkdAmount: number,
-  underlyingCode: string
-): number {
-  if (isIndexCode(underlyingCode)) {
-    // Для индексов: сначала делим на 50, потом умножаем на курс
-    return (hkdAmount / INDEX_MULTIPLIER) * HKD_TO_USD_RATE;
-  } else {
-    // Для обычных активов: просто умножаем на курс
-    return hkdAmount * HKD_TO_USD_RATE;
-  }
+export function convertHKDToUSD(hkdAmount: number): number {
+  // Для всех типов активов: просто умножаем на курс
+  return hkdAmount * HKD_TO_USD_RATE;
 }
 
 /**
  * Форматирует валютную пару HKD/USD
  */
-export function formatCurrencyPair(
-  hkdAmount: number,
-  underlyingCode: string
-): {
+export function formatCurrencyPair(hkdAmount: number): {
   hkd: string;
   usd: string;
 } {
-  const usdAmount = convertHKDToUSD(hkdAmount, underlyingCode);
+  const usdAmount = convertHKDToUSD(hkdAmount);
   return {
     hkd: toAbbreviatedNumber(hkdAmount),
     usd: toAbbreviatedNumber(usdAmount),


### PR DESCRIPTION
- Remove division by 50 for index underlyings in Equivalent column
- Simplify convertHKDToUSD function to take only one parameter
- Remove unused underlyingCode parameters from table components
- Update table headers to show 'Equivalent' instead of 'Equivalent (futures/shares)'
- Clean up unused imports and parameters
- Ensure all components work without index-specific logic