### PR TITLE
fix: display empty ranges with dashes in CBBC matrix table

### DIFF
--- a/src/components/CBBCTable/CBBCMatrixRow.tsx
+++ b/src/components/CBBCTable/CBBCMatrixRow.tsx
@@ -53,18 +53,8 @@ export default function CBBCMatrixRow({
   console.log("range", range, "dateList", dateList);
   console.log("activeDate", activeDate);
 
-  // Проверяем, есть ли данные хотя бы за одну дату
-  const hasAnyData = dateList.some((date) => {
-    const cell = cellForDate(date);
-    return cell && cell.notional > 0;
-  });
-
-  console.log(`Диапазон ${range} имеет данные:`, hasAnyData);
-
-  // Если нет данных ни за одну дату, не показываем строку
-  if (!hasAnyData) {
-    return null;
-  }
+  // Всегда показываем строку, даже если нет данных
+  // (пустые диапазоны должны отображаться с прочерками)
 
   return (
     <Fragment>
@@ -101,9 +91,7 @@ export default function CBBCMatrixRow({
               );
             } else {
               // Если есть данные в активной дате, показываем их
-              const { hkd, usd } = formatCurrencyPair(
-                cell.notional
-              );
+              const { hkd, usd } = formatCurrencyPair(cell.notional);
 
               return (
                 <Fragment key={`${range}-${date}-active`}>
@@ -148,9 +136,7 @@ export default function CBBCMatrixRow({
             }
           } else if (idx > 0 && idx < 4) {
             // Для остальных дат показываем данные, если они есть
-            const { hkd, usd } = formatCurrencyPair(
-              cell?.notional || 0
-            );
+            const { hkd, usd } = formatCurrencyPair(cell?.notional || 0);
 
             return (
               <td

--- a/src/hooks/useCBBCMatrixData.ts
+++ b/src/hooks/useCBBCMatrixData.ts
@@ -33,15 +33,16 @@ export function useCBBCMatrixData(
     for (const row of groupedRawData) {
       const { date, range, cbcc_list } = row;
 
-      if (!Array.isArray(cbcc_list)) {
-        console.warn("cbcc_list is not an array:", cbcc_list);
-        continue;
-      }
-
+      // Всегда добавляем диапазон, даже если cbcc_list пустой
       ranges.add(range);
       if (!dates.includes(date)) dates.push(date);
 
-      if (!priceByDate[date] && cbcc_list.length > 0) {
+      // Получаем цену андерлайна, если есть данные
+      if (
+        !priceByDate[date] &&
+        Array.isArray(cbcc_list) &&
+        cbcc_list.length > 0
+      ) {
         priceByDate[date] = cbcc_list[0].ul_price;
       }
     }
@@ -69,14 +70,9 @@ export function useCBBCMatrixData(
         continue;
       }
 
-      const filteredList: GroupedCBBCEntry[] =
-        Array.isArray(selectedIssuers) && selectedIssuers.length > 0
-          ? cbcc_list.filter((cbcc: GroupedCBBCEntry) =>
-              selectedIssuers.includes(cbcc.issuer)
-            )
-          : cbcc_list;
-
-      if (filteredList.length === 0) {
+      // Обрабатываем случай, когда cbcc_list не является массивом или пустой
+      if (!Array.isArray(cbcc_list) || cbcc_list.length === 0) {
+        // Убеждаемся, что ячейки инициализированы с нулевыми значениями
         if (
           !matrix[range][date].Bull.notional &&
           !matrix[range][date].Bear.notional
@@ -96,6 +92,18 @@ export function useCBBCMatrixData(
             items: [],
           };
         }
+        continue;
+      }
+
+      const filteredList: GroupedCBBCEntry[] =
+        Array.isArray(selectedIssuers) && selectedIssuers.length > 0
+          ? cbcc_list.filter((cbcc: GroupedCBBCEntry) =>
+              selectedIssuers.includes(cbcc.issuer)
+            )
+          : cbcc_list;
+
+      if (filteredList.length === 0) {
+        // Если после фильтрации нет данных, оставляем ячейки с нулевыми значениями
         continue;
       }
 


### PR DESCRIPTION
- Remove hasAnyData check that was hiding empty ranges
- Always show all ranges, even those with no data (cbcc_list: [])
- Initialize matrix cells with zero values for empty ranges
- Ensure empty ranges display dashes (–) in all columns
- Fix handling of ranges with count: 0 and empty cbcc_list
- Improve data processing logic for empty CBBC entries