### PR TITLE
feat: apply index multiplier (50) only in Equivalent column\n\n- Dete…

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import CBBCDashboardStats from "@/components/CBBCDashboardStats";
 import DashboardContent from "@/components/dashboard/DashboardContent";
 import { useDashboardData } from "@/hooks/useDashboardData";
 import { useDashboardFilters } from "@/hooks/useDashboardFilters";
+import { formatUnderlyingCode } from "@/lib/utils";
 
 export default function DashboardPageV2() {
   // Use custom hooks for data and filter management
@@ -78,6 +79,14 @@ export default function DashboardPageV2() {
         isLoadingSingleDate={isLoadingSingleDate}
         singleDateQueryError={singleDateQuery.error}
         singleDateQuery={singleDateQuery}
+        isIndexUnderlying={(() => {
+          const code = filters.underlying;
+          if (!code) return false;
+          const found = underlyings.find(
+            (u) => formatUnderlyingCode(u.code) === code
+          );
+          return found?.type === "index";
+        })()}
       />
     </div>
   );

--- a/src/components/CBBCTable/CBBCMatrixRow.tsx
+++ b/src/components/CBBCTable/CBBCMatrixRow.tsx
@@ -37,6 +37,7 @@ type Props = {
   prevDate?: string;
   isExpanded: boolean;
   onToggle: (range: string) => void;
+  isIndexUnderlying?: boolean;
 };
 
 export default function CBBCMatrixRow({
@@ -47,6 +48,7 @@ export default function CBBCMatrixRow({
   prevDate,
   isExpanded,
   onToggle,
+  isIndexUnderlying = false,
 }: Props) {
   const cellForDate = (date: string) => matrix[range]?.[date];
 
@@ -122,7 +124,13 @@ export default function CBBCMatrixRow({
                   </td>
                   <td className="p-1 border border-gray-300 min-w-[100px] text-center bg-white">
                     <div className="flex items-center justify-center px-1 text-xs text-black font-semibold">
-                      {toAbbreviatedNumber(Math.round(cell.shares || 0))}
+                      {toAbbreviatedNumber(
+                        Math.round(
+                          (isIndexUnderlying
+                            ? (cell.shares || 0) / 50
+                            : cell.shares || 0) || 0
+                        )
+                      )}
                     </div>
                   </td>
                   <td className="p-1 text-center border border-gray-300 max-w-[200px] truncate bg-white">

--- a/src/components/CBBCTable/GroupedCBBCMetricsMatrix.tsx
+++ b/src/components/CBBCTable/GroupedCBBCMetricsMatrix.tsx
@@ -14,6 +14,7 @@ type Props = {
   bullMatrix: Record<string, Record<string, AggregatedCell>>;
   bearMatrix: Record<string, Record<string, AggregatedCell>>;
   priceByDate: Record<string, number>;
+  isIndexUnderlying?: boolean;
 };
 
 export default function CBBCMatrixTable({
@@ -24,6 +25,7 @@ export default function CBBCMatrixTable({
   bullMatrix,
   bearMatrix,
   priceByDate,
+  isIndexUnderlying = false,
 }: Props) {
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
   const [showAllBearRanges, setShowAllBearRanges] = useState(false);
@@ -128,6 +130,7 @@ export default function CBBCMatrixTable({
                 prevDate={prevDate}
                 isExpanded={expandedRows[`${range}-Bear`] || false}
                 onToggle={() => toggleRow(range, "Bear")}
+                isIndexUnderlying={isIndexUnderlying}
               />
             </Fragment>
           ))}
@@ -164,6 +167,7 @@ export default function CBBCMatrixTable({
                 prevDate={prevDate}
                 isExpanded={expandedRows[`${range}-Bull`] || false}
                 onToggle={() => toggleRow(range, "Bull")}
+                isIndexUnderlying={isIndexUnderlying}
               />
             </Fragment>
           ))}

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -29,6 +29,7 @@ interface DashboardContentProps {
   // Query state
   singleDateQueryError?: any;
   singleDateQuery: any;
+  isIndexUnderlying?: boolean;
 }
 
 /**
@@ -50,6 +51,7 @@ export default function DashboardContent({
   isLoadingSingleDate,
   singleDateQueryError,
   singleDateQuery,
+  isIndexUnderlying = false,
 }: DashboardContentProps) {
   const { sendErrorNotification } = useErrorNotification();
   const lastErrorRef = useRef<string | null>(null);
@@ -102,6 +104,7 @@ export default function DashboardContent({
             bullMatrix={singleDateMatrixData.bullMatrix}
             bearMatrix={singleDateMatrixData.bearMatrix}
             priceByDate={singleDateMatrixData.priceByDate}
+            isIndexUnderlying={isIndexUnderlying}
           />
         </div>
       );
@@ -152,6 +155,7 @@ export default function DashboardContent({
         bullMatrix={bullMatrix}
         bearMatrix={bearMatrix}
         priceByDate={priceByDate}
+        isIndexUnderlying={isIndexUnderlying}
       />
     );
   }


### PR DESCRIPTION
…ct underlying type from underlyings list\n- Pass isIndexUnderlying flag through dashboard into matrix\n- Divide Equivalent value by 50 only for index underlyings\n- No other metrics use multiplier